### PR TITLE
Added distortion model based on OpenNI2 ROS driver

### DIFF
--- a/src/thin_astra_node.cpp
+++ b/src/thin_astra_node.cpp
@@ -1,6 +1,7 @@
 #include <ros/ros.h>
 #include <sensor_msgs/Image.h>
 #include <sensor_msgs/CameraInfo.h>
+#include <sensor_msgs/distortion_models.h>
 #include <stdio.h>
 #include <iostream>
 #include <OpenNI.h>
@@ -86,6 +87,10 @@ void* camera_thread(void*){
 	  depth_info.height=frame.getHeight();
 
 	  depth_info.header.seq = count;
+
+    depth_info.distortion_model = sensor_msgs::distortion_models::PLUMB_BOB;
+    depth_info.D.resize(5, 0.0);
+
 	  depth_info.K[0]=depth_info.width/(2*tan(depth.getHorizontalFieldOfView()/2)); //fx
 	  depth_info.K[4]=depth_info.height/(2*tan(depth.getVerticalFieldOfView()/2));; //fy
 	  depth_info.K[2]=depth_info.width/2; //cx


### PR DESCRIPTION
Distortion model is needed for rectifying images. It is now implemented the same way as the OpenNI2 driver in openni2_camera: https://github.com/ros-drivers/openni2_camera/blob/2dc246feb39f13a8e7f8b362dc1c5478abae668d/src/openni2_driver.cpp#L490